### PR TITLE
add a firefox addon

### DIFF
--- a/firefox/Makefile
+++ b/firefox/Makefile
@@ -1,0 +1,4 @@
+all:
+	cfx xpi --update-link https://people.debian.org/~geissert/ace-debsources/ace-sourced_n.xpi --update-url https://people.debian.org/~geissert/ace-debsources/updates.rdf
+	mv ace-sourced_n.update.rdf updates.rdf
+	sed -i 's/maxVersion>[^<]*/maxVersion>38.0/' updates.rdf

--- a/firefox/data/loader.js
+++ b/firefox/data/loader.js
@@ -1,0 +1,6 @@
+base = 'https://people.debian.org/~geissert/ace-debsources/';
+
+insertjs = document.createElement('script');
+insertjs.type = 'text/javascript';
+insertjs.src = base+'/injector.js';
+document.body.appendChild(insertjs);

--- a/firefox/lib/main.js
+++ b/firefox/lib/main.js
@@ -1,0 +1,6 @@
+const data = require("sdk/self").data;
+const pageMod = require("sdk/page-mod");
+pageMod.PageMod({
+  include: "http://sources.debian.net/src/*",
+  contentScriptFile: data.url("loader.js")
+});

--- a/firefox/package.json
+++ b/firefox/package.json
@@ -1,0 +1,9 @@
+{
+  "name": "ace-sourced_n",
+  "title": "ACE editor for sources.d.n",
+  "id": "jid1-7XXcASw2cOyYxg",
+  "description": "In-browser editing of Debian sources, yay!",
+  "author": "",
+  "license": "MPL 2.0",
+  "version": "0.0.4"
+}

--- a/web/injector.js
+++ b/web/injector.js
@@ -36,7 +36,7 @@ function acedebsources_inject() {
     var editlink, separator, parentfolderlink;
 
     for (var i = 0; i < a_elems.length; i++) {
-	if (a_elems[i].innerText == 'parent folder') {
+	if (a_elems[i].textContent == 'parent folder') {
 	    parentfolderlink = a_elems[i];
 
 	    separator = document.createElement('span');

--- a/web/injector.js
+++ b/web/injector.js
@@ -47,6 +47,9 @@ function acedebsources_inject() {
 	    editlink.textContent = 'edit';
 	    editlink.id = 'editcode_trigger';
 	    editlink.href = 'javascript:editcode();';
+	    editlink.onclick = function() {
+		    editcode();
+	    };
 	    parentfolderlink.parentElement.insertBefore(editlink, parentfolderlink.nextElementSibling);
 	}
     }


### PR DESCRIPTION
code of firefox addon inside `firefox/` folder
some changes on `injector.js` to support firefox
build script is available on `Makefile`, but a packaged addon is available to download from http://lejenome.me/tests/ace-sourced_n.xpi
